### PR TITLE
Feature/team manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# home-manager template
+# home-manager team template
 
 This provides a quick-start template for using
 [home-manager](https://github.com/rycee/home-manager) in a more
-reproducible way. You don't have to install home-manager, and it uses
-pinning.
+reproducible way for multiple team members.
+
+NB: You don't have to install home-manager, and it uses pinning.
 
 # Why?
 
@@ -70,16 +71,7 @@ can load a version of nixpkgs that suffers from clang errors.
    ```
 
 3. Edit your [home configuration](#Home configuration) to be how you want it.
-4. Create, if missing, ~/.me.d/ personalisation files:
-
-   mkdir -p ~/.me.d
-   cat > ~/.me.d/git.nix
-   {
-     email = "your.email@example.com";
-     name = "Your Name";
-   }
-
-5. Run the switch script to switch to your configuration:
+4. Run the switch script to switch to your configuration:
 
     ```sh
     ./switch.sh
@@ -100,12 +92,9 @@ This home-manager configuration is intended as a baseline for shared configurati
 The 'default' configuration provided by this configuration is in [home.nix](home.nix)
 which imports all modules from [lib/defaults](lib/defaults).
 
-## Personalisation ##
+## Required ##
 
-All personalised configuration is loaded from all your `~/.me.d/*.nix` files. You can
-split out your personalised configuration in any .nix files you like in that directory.
-
-At a minimum you will want to configure git with your userName and userEmail.
+At a minimum you should configure git with your userName and userEmail.
 
 Example `~/.me.d/git.nix` module:
 
@@ -114,6 +103,11 @@ Example `~/.me.d/git.nix` module:
       programs.git.userEmail = "your.email@example.com";
       programs.git.userName = "Your Name";
     }
+
+## Personalisation ##
+
+All personalised configuration is loaded from all your `~/.me.d/*.nix` files. You can
+split out your personalised configuration in any .nix files you like in that directory.
 
 # Caveats
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl -L https://nixos.org/nix/install | sh
 
 # Setup
 
-1. Click the "Use this template" button on GitHub
+1. Click the "Use this template" or "Code" button on GitHub
 1. Clone your repository onto the computer you want to configure
 1. Initialise pinned dependencies (home-manager and nixpkgs) with the latest version:
 
@@ -69,7 +69,7 @@ can load a version of nixpkgs that suffers from clang errors.
    nix-shell --run "home-manager news" [shell.nix]
    ```
 
-3. Edit `./home.nix` to be how you want it.
+3. Edit your [home configuration](#Home configuration) to be how you want it.
 4. Create, if missing, ~/.me.d/ personalisation files:
 
    mkdir -p ~/.me.d
@@ -91,6 +91,30 @@ can load a version of nixpkgs that suffers from clang errors.
     nix-shell --run "home-manager switch"
     ```
 
+# Home configuration
+
+This home-manager configuration is intended as a baseline for shared configurations for a team.
+
+## Defaults ##
+
+The 'default' configuration provided by this configuration is in [home.nix](home.nix)
+which imports all modules from [lib/defaults](lib/defaults).
+
+## Personalisation ##
+
+All personalised configuration is loaded from all your `~/.me.d/*.nix` files. You can
+split out your personalised configuration in any .nix files you like in that directory.
+
+At a minimum you will want to configure git with your userName and userEmail.
+
+Example `~/.me.d/git.nix` module:
+
+    {}:
+    {
+      programs.git.userEmail = "your.email@example.com";
+      programs.git.userName = "Your Name";
+    }
+
 # Caveats
 
 Since we do not install home-manager, you need to let home-manager
@@ -101,4 +125,3 @@ Please consult home-manager documentation for exact required steps.
 Also since we do not install home-manager, you cannot run the
 home-manager script from any directory and expect it to work. It must
 be run from within the nix-shell. (This is actually a feature!)
-

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ can load a version of nixpkgs that suffers from clang errors.
    nix-shell --run "home-manager news" [shell.nix]
    ```
 
-3. Edit your [home configuration](#Home configuration) to be how you want it.
+3. Edit your [home configuration](#home-configuration) to be how you want it.
 4. Run the switch script to switch to your configuration:
 
     ```sh

--- a/home.nix
+++ b/home.nix
@@ -3,49 +3,83 @@
 let
 
   # ---------------------------------------------------------
+  # ENV
+  # ---------------------------------------------------------
+
+  env = rec {
+    homedir = builtins.getEnv "HOME";
+    username = builtins.getEnv "USER";
+    baseDir = "${toString ./.}";
+    meDir = "${homedir}/.me.d";
+  };
+
+  # ---------------------------------------------------------
   # FUNCTIONS
   # ---------------------------------------------------------
 
-  tryGetAttr = key: set: msg:
+  helpers = rec {
+    tryGetAttr = key: set: msg:
      if builtins.hasAttr key set
      then builtins.getAttr key set
      else throw msg;
 
-  optImport = path: default:
-    if builtins.pathExists path
-    then import path
-    else default;
+    optImport = path: default:
+      if builtins.pathExists path
+      then import path
+      else default;
 
-  tryImport = path:
-    if builtins.pathExists path
-    then import path
-    else throw "${path} does not exist";
+    tryImport = path:
+      if builtins.pathExists path
+      then import path
+      else throw "${path} does not exist";
 
-  mePath = name: "${homedir}/.me.d/${name}.nix";
+    defaultPath = name: "${env.baseDir}/defaults}/${name}.nix";
+    mePath = name: "${env.meDir}/${name}.nix";
 
-  meOptConfig = name: default:
-    optImport (mePath name) default;
+    optCallPackage = package: args: default:
+      if builtins.pathExists package
+      then pkgs.callPackage package args
+      else default;
+  };
+
 
   # ---------------------------------------------------------
   # VARIABLES
   # ---------------------------------------------------------
 
-  homedir = builtins.getEnv "HOME";
-  username = builtins.getEnv "USER";
+  functionArgs = {
+    pkgs = pkgs;
+    env = env;
+    helpers = helpers;
+  };
 
-  fullname = tryGetAttr "name"
-                        (tryImport (mePath "git"))
-                        "${mePath "git"} not found";
+  defaultHome = with helpers; optCallPackage (defaultPath "home") functionArgs {};
+  defaultPrograms = with helpers; optCallPackage (defaultPath "home")  functionArgs {};
 
-  email = tryGetAttr "email"
-                     (tryImport (mePath "git"))
-                     "${mePath "git"} not found";
+  customHomeArgs = { defaults = defaultHome; } // functionArgs;
+  customHome = with helpers; optCallPackage (mePath "home") customHomeArgs {};
 
-  shellAliases = meOptConfig "aliases" {};
-  sessionVars = meOptConfig "sessionVariables" {};
+  customProgramsArgs = { defaults = defaultPrograms; } // functionArgs;
+  customPrograms = with helpers; optCallPackage (mePath "programs") customProgramsArgs {};
 
 in
 {
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes.
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release.
+  home = defaultHome // customHome // { stateVersion = "20.09"; };
+
+  # If you use non-standard XDG locations, set these options to the
+  # appropriate paths:
+  #
+  # xdg.cacheHome
+  # xdg.configHome
+  # xdg.dataHome
 
   # The home-manager manual is at:
   #
@@ -60,113 +94,7 @@ in
   #
   # You need to change these to match your username and home directory
   # path:
-  home.username = username;
-  home.homeDirectory = homedir;
-  home.sessionVariables = sessionVars;
 
-  # If you use non-standard XDG locations, set these options to the
-  # appropriate paths:
-  #
-  # xdg.cacheHome
-  # xdg.configHome
-  # xdg.dataHome
-
-  # This value determines the Home Manager release that your
-  # configuration is compatible with. This helps avoid breakage
-  # when a new Home Manager release introduces backwards
-  # incompatible changes.
-  #
-  # You can update Home Manager without changing this value. See
-  # the Home Manager release notes for a list of state version
-  # changes in each release.
-  home.stateVersion = "20.09";
-
-  # ----------------------------------------------------------------
-  # programs
-  # ----------------------------------------------------------------
-  programs.autojump.enable = true;
-
-  # Since we do not install home-manager, you need to let home-manager
-  # manage your shell, otherwise it will not be able to add its hooks
-  # to your profile.
-  programs.bash.enable = true;
-  programs.bash.shellAliases = shellAliases;
-  programs.direnv.enable = true;
-
-  programs.emacs = {
-    enable = true;
-    extraPackages = epkgs: with epkgs; [
-      nix-mode
-      magit
-    ];
-  };
-
-  programs.git = {
-    enable = true;
-    userName = fullname;
-    userEmail = email;
-    aliases = {
-      unstage = "reset HEAD --";
-      pr = "pull --rebase";
-      co = "checkout";
-      ci = "commit";
-      c = "commit";
-      b = "branch";
-      p = "push";
-      d = "diff";
-      a = "add";
-      s = "status";
-      f = "fetch";
-      br = "branch";
-      lr = "reflog";
-      l = "log --graph --pretty='%Cred%h%Creset - %C(bold blue)<%an>%Creset %s%C(yellow)%d%Creset %Cgreen(%cr)' --abbrev-commit --date=relative";
-      hist = "log --branches --remotes --decorate --graph --pretty=format:'%C(auto) %>|(15) %h %d %<|(30trunc) %s %>|(100)%C(cyan)%ci %C(yellow)%an %C(cyan)(%ar)'";
-      h = "hist";
-    };
-    ignores = [ "*~" "__pycache__" "*.pyc" "*.swp" ".*-cache" "build/" ];
-    extraConfig = {
-      merge.conflictstyle = "diff3";
-      pull.rebase = true;
-      core.quotepath = true;
-    };
-  };
-
-  programs.home-manager.enable = true;
-
-  programs.zsh = {
-    enable = true;
-    shellAliases = shellAliases;
-  };
-
-  home.packages = with pkgs; [
-    # example packages
-    htop
-    fortune
-
-    # nix basics
-    niv
-    nixfmt
-    nix-prefetch-github
-    nix-prefetch-scripts
-    undmg
-    styx
-
-    # basics
-    aspell
-    bc
-    clang
-    coreutils
-    fd
-    ffmpeg
-    gdb
-    gnupg
-    jq
-    nox
-    perl
-    ripgrep
-    silver-searcher
-    taskwarrior
-    tree
-  ];
+  programs = defaultPrograms // customPrograms;
 
 }

--- a/home.nix
+++ b/home.nix
@@ -1,6 +1,7 @@
 { pkgs, lib, ... }:
 
 let
+  debugCallPackage = false;
 
   # ---------------------------------------------------------
   # ENV
@@ -38,8 +39,9 @@ let
 
     optCallPackage = package: args: default:
       if builtins.pathExists package
-      then import package args
-      #then pkgs.callPackage package args
+      then (if debugCallPackage
+            then pkgs.callPackage package args
+            else import package args)
       else default;
   };
 
@@ -49,11 +51,12 @@ let
   # ---------------------------------------------------------
 
   functionArgs = {
-    pkgs = pkgs;
-    lib = lib;
     env = env;
     helpers = helpers;
-  };
+  } // (if !debugCallPackage then {
+    pkgs = pkgs;
+    lib = lib;
+  } else {});
 
   mkFunctionArgs = args:
     functionArgs // { defaults = args; };

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, stdenv, lib, ... }:
 
 let
 
@@ -38,7 +38,8 @@ let
 
     optCallPackage = package: args: default:
       if builtins.pathExists package
-      then pkgs.callPackage package args
+      then import package args
+      #then pkgs.callPackage package args
       else default;
   };
 
@@ -49,6 +50,8 @@ let
 
   functionArgs = {
     pkgs = pkgs;
+    stdenv = stdenv;
+    lib = lib;
     env = env;
     helpers = helpers;
   };

--- a/home.nix
+++ b/home.nix
@@ -54,7 +54,7 @@ let
   };
 
   defaultHome = with helpers; optCallPackage (defaultPath "home") functionArgs {};
-  defaultPrograms = with helpers; optCallPackage (defaultPath "home")  functionArgs {};
+  defaultPrograms = with helpers; optCallPackage (defaultPath "programs")  functionArgs {};
 
   customHomeArgs = { defaults = defaultHome; } // functionArgs;
   customHome = with helpers; optCallPackage (mePath "home") customHomeArgs {};

--- a/home.nix
+++ b/home.nix
@@ -33,7 +33,7 @@ let
       then import path
       else throw "${path} does not exist";
 
-    defaultPath = name: "${env.baseDir}/defaults}/${name}.nix";
+    defaultPath = name: "${env.baseDir}/lib/defaults/${name}.nix";
     mePath = name: "${env.meDir}/${name}.nix";
 
     optCallPackage = package: args: default:

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, lib, ... }:
+{ pkgs, lib, ... }:
 
 let
 
@@ -50,7 +50,6 @@ let
 
   functionArgs = {
     pkgs = pkgs;
-    stdenv = stdenv;
     lib = lib;
     env = env;
     helpers = helpers;

--- a/home.nix
+++ b/home.nix
@@ -53,14 +53,19 @@ let
     helpers = helpers;
   };
 
-  defaultHome = with helpers; optCallPackage (defaultPath "home") functionArgs {};
-  defaultPrograms = with helpers; optCallPackage (defaultPath "programs")  functionArgs {};
+  mkFunctionArgs = args:
+    functionArgs // { defaults = args; };
 
-  customHomeArgs = { defaults = defaultHome; } // functionArgs;
-  customHome = with helpers; optCallPackage (mePath "home") customHomeArgs {};
+in
 
-  customProgramsArgs = { defaults = defaultPrograms; } // functionArgs;
-  customPrograms = with helpers; optCallPackage (mePath "programs") customProgramsArgs {};
+ with helpers;
+ let
+
+  defaultHome = optCallPackage (defaultPath "home") functionArgs {};
+  customHome = optCallPackage (mePath "home") (mkFunctionArgs defaultHome) {};
+
+  defaultPrograms = optCallPackage (defaultPath "programs")  functionArgs {};
+  customPrograms = optCallPackage (mePath "programs") (mkFunctionArgs defaultPrograms) {};
 
 in
 {

--- a/home.nix
+++ b/home.nix
@@ -1,82 +1,40 @@
 { pkgs, lib, ... }:
 
 let
-  debugCallPackage = false;
 
   # ---------------------------------------------------------
-  # ENV
+  # ENVIRONMENT
   # ---------------------------------------------------------
 
-  env = rec {
-    homedir = builtins.getEnv "HOME";
-    username = builtins.getEnv "USER";
-    baseDir = "${toString ./.}";
-    meDir = "${homedir}/.me.d";
-  };
+  homeDir = builtins.getEnv "HOME";
+  userName = builtins.getEnv "USER";
+
+  libDir = ./lib/defaults;
+  meDir = "${homeDir}/.me.d";
 
   # ---------------------------------------------------------
   # FUNCTIONS
   # ---------------------------------------------------------
 
-  helpers = rec {
-    tryGetAttr = key: set: msg:
-     if builtins.hasAttr key set
-     then builtins.getAttr key set
-     else throw msg;
-
-    optImport = path: default:
-      if builtins.pathExists path
-      then import path
-      else default;
-
-    tryImport = path:
-      if builtins.pathExists path
-      then import path
-      else throw "${path} does not exist";
-
-    defaultPath = name: "${env.baseDir}/lib/defaults/${name}.nix";
-    mePath = name: "${env.meDir}/${name}.nix";
-
-    optCallPackage = package: args: default:
-      if builtins.pathExists package
-      then (if debugCallPackage
-            then pkgs.callPackage package args
-            else import package args)
-      else default;
-  };
-
+  nixFilesIn = dir: with builtins;
+    map
+      (f: "${dir}/${f}")
+      (filter
+        (f: lib.strings.hasSuffix ".nix" "${f}")
+        (builtins.attrNames (builtins.readDir dir)));
 
   # ---------------------------------------------------------
   # VARIABLES
   # ---------------------------------------------------------
 
-  functionArgs = {
-    env = env;
-    helpers = helpers;
-  } // (if !debugCallPackage then {
-    pkgs = pkgs;
-    lib = lib;
-  } else {});
-
-  mkFunctionArgs = args:
-    functionArgs // { defaults = args; };
+  modules = []
+    ++ nixFilesIn libDir
+    ++ nixFilesIn meDir;
 
 in
-
- with helpers;
- let
-
-   defaultHome = optCallPackage (defaultPath "home") functionArgs {};
-   customHome = optCallPackage (mePath "home") (mkFunctionArgs defaultHome) {};
-
-   defaultPrograms = optCallPackage (defaultPath "programs")  functionArgs {};
-   customPrograms = optCallPackage (mePath "programs") (mkFunctionArgs defaultPrograms) {};
-
-   homeManagement = defaultHome // customHome // { stateVersion = "20.09"; };
-   programsManagement = defaultPrograms // customPrograms;
-
- in
 {
+  imports = modules;
+
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards
@@ -85,29 +43,6 @@ in
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
   # changes in each release.
-  home = homeManagement;
-
-  # If you use non-standard XDG locations, set these options to the
-  # appropriate paths:
-  #
-  # xdg.cacheHome
-  # xdg.configHome
-  # xdg.dataHome
-
-  # The home-manager manual is at:
-  #
-  #   https://rycee.gitlab.io/home-manager/release-notes.html
-  #
-  # Configuration options are documented at:
-  #
-  #   https://rycee.gitlab.io/home-manager/options.html
-
-  # Home Manager needs a bit of information about you and the
-  # paths it should manage.
-  #
-  # You need to change these to match your username and home directory
-  # path:
-
-  programs = programsManagement;
-
+  #stateVersion = "20.09";
+  home.stateVersion = "20.09";
 }

--- a/home.nix
+++ b/home.nix
@@ -61,13 +61,16 @@ in
  with helpers;
  let
 
-  defaultHome = optCallPackage (defaultPath "home") functionArgs {};
-  customHome = optCallPackage (mePath "home") (mkFunctionArgs defaultHome) {};
+   defaultHome = optCallPackage (defaultPath "home") functionArgs {};
+   customHome = optCallPackage (mePath "home") (mkFunctionArgs defaultHome) {};
 
-  defaultPrograms = optCallPackage (defaultPath "programs")  functionArgs {};
-  customPrograms = optCallPackage (mePath "programs") (mkFunctionArgs defaultPrograms) {};
+   defaultPrograms = optCallPackage (defaultPath "programs")  functionArgs {};
+   customPrograms = optCallPackage (mePath "programs") (mkFunctionArgs defaultPrograms) {};
 
-in
+   homeManagement = defaultHome // customHome // { stateVersion = "20.09"; };
+   programsManagement = defaultPrograms // customPrograms;
+
+ in
 {
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
@@ -77,7 +80,7 @@ in
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
   # changes in each release.
-  home = defaultHome // customHome // { stateVersion = "20.09"; };
+  home = homeManagement;
 
   # If you use non-standard XDG locations, set these options to the
   # appropriate paths:
@@ -100,6 +103,6 @@ in
   # You need to change these to match your username and home directory
   # path:
 
-  programs = defaultPrograms // customPrograms;
+  programs = programsManagement;
 
 }

--- a/lib/defaults/home.nix
+++ b/lib/defaults/home.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, env, helpers, ... }:
+{ lib, pkgs, env, helpers, ... }:
 
 let
   #
@@ -166,7 +166,7 @@ let
     markdown
     nix-system
   ]
-  ++ lib.optionals stdenv.isDarwin ([
+  ++ lib.optionals pkgs.stdenv.isDarwin ([
     app-path
     idownload
     nix-link-macapps

--- a/lib/defaults/home.nix
+++ b/lib/defaults/home.nix
@@ -1,6 +1,9 @@
-{ lib, pkgs, env, helpers, ... }:
+{ lib, pkgs, ... }:
 
 let
+  homeDir = builtins.getEnv "HOME";
+  userName = builtins.getEnv "USER";
+
   #
   # CUSTOM GENERIC PACKAGES
   #
@@ -177,54 +180,45 @@ let
 
 in
 {
-  # This value determines the Home Manager release that your
-  # configuration is compatible with. This helps avoid breakage
-  # when a new Home Manager release introduces backwards
-  # incompatible changes.
-  #
-  # You can update Home Manager without changing this value. See
-  # the Home Manager release notes for a list of state version
-  # changes in each release.
-  #stateVersion = "20.09";
+  home = {
 
-  username = env.username;
-  homeDirectory = env.homedir;
+    homeDirectory = homeDir;
+    username = userName;
 
-  sessionVariables = helpers.meOptConfig "sessionVariables" {};
+    packages = with pkgs; [
+      # EXAMPLES
+      htop
+      fortune
 
-  packages = with pkgs; [
-    # EXAMPLES
-    htop
-    fortune
+      # NIX BASICS
+      niv
+      nixfmt
+      nix-prefetch-github
+      nix-prefetch-scripts
+      undmg
+      styx
 
-    # NIX BASICS
-    niv
-    nixfmt
-    nix-prefetch-github
-    nix-prefetch-scripts
-    undmg
-    styx
+      # TOOLS
+      aspell
+      bc
+      clang
+      coreutils
+      fd
+      ffmpeg
+      gdb
+      gnupg
+      jq
+      nox
+      perl
+      ripgrep
+      silver-searcher
+      taskwarrior
+      tree
+      python38Packages.yamllint
 
-    # TOOLS
-    aspell
-    bc
-    clang
-    coreutils
-    fd
-    ffmpeg
-    gdb
-    gnupg
-    jq
-    nox
-    perl
-    ripgrep
-    silver-searcher
-    taskwarrior
-    tree
-    python38Packages.yamllint
-
-    # CLOUD
-    awscli2
-  ]
-  ++ customPackages;
+      # CLOUD
+      awscli2
+    ]
+    ++ customPackages;
+  };
 }

--- a/lib/defaults/home.nix
+++ b/lib/defaults/home.nix
@@ -1,0 +1,230 @@
+{ lib, stdenv, pkgs, env, helpers, ... }:
+
+let
+  #
+  # CUSTOM GENERIC PACKAGES
+  #
+  future-git = pkgs.writeShellScriptBin "future-git" ''
+    function help {
+      echo "Usage: $0 <hours> [<git args>]"
+      exit 1
+    }
+
+    if [ $# -eq 0 ]; then
+      help
+    fi
+
+    items=( "$@" )
+    (for e in "''${items[@]}"; do [[ "$e" =~ ^(--)?help$ ]] && exit 0; done; exit 1) && help
+
+    HOURS=4
+    re='^[0-9]+$'
+    if [[ $1 =~ $re ]]; then
+      HOURS=$1
+      shift
+    fi
+
+    DATE="$(date -d +''${HOURS}hours)"
+    GIT_AUTHOR_DATE="''${DATE}" GIT_COMMITTER_DATE="''${DATE}" git "$@"
+  '';
+
+  jqo = pkgs.writeShellScriptBin "jqo" ''
+    ${pkgs.jq}/bin/jq -R -r 'capture("(?<prefix>[^{]*)(?<json>{.+})?(?<suffix>.*)") | .prefix,(.json|try fromjson catch ""),.suffix | select(length > 0)'
+  '';
+
+  markdown = pkgs.emem.overrideAttrs (oldAttrs: rec {
+    installPhase = oldAttrs.installPhase + ''
+      ln -fs $out/bin/emem $out/bin/markdown
+    '';
+  });
+
+  nix-system = pkgs.writeShellScriptBin "nix-system" ''
+    echo 'nix-shell -p nix-info --run "nix-info -m"'
+    nix-shell -p nix-info --run "nix-info -m"
+  '';
+
+  #
+  # CUSTOM DARWIN PACKAGES
+  #
+
+  app-path = pkgs.writeShellScriptBin "app-path" ''
+    color()(set -o pipefail;"$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
+    echoerr() { echo "$@" 1>&2; }
+    function indented() {
+        (set -o pipefail; { "$@" 2>&3 | sed >&2 's/^/   | /'; } 3>&1 1>&2 | perl -pe 's/^(.*)$/\e[31m   | $1\e[0m/')
+    }
+    function join_by { local d=$1; shift; local f=$1; shift; printf %s "$f" "''${@/#/$d}"; }
+    function usage {
+      echo "Usage: app-path fuzzyname..."
+      exit 1
+    }
+    [[ $# -lt 1 ]] && usage
+
+    LOCATIONS=( "$HOME/.nix-profile/Applications" "$HOME/.nix-profile/Applications/Utilities" "$HOME/Applications" "$HOME/Applications/Utilities" "/Applications" "/Applications/Utilities" "/System/Applications" "/System/Applications/Utilities" )
+    MATCHER=$(join_by '.*' "$@")
+
+    APP=""
+    for l in "''${LOCATIONS[@]}"; do
+      if ! [ -d $l ]; then
+        continue;
+      fi
+      NAME=$(ls "$l" | grep -i "$MATCHER")
+      COUNT=$(echo "$NAME" | grep -v -e '^$' | wc -l)
+      if [[  $COUNT -gt 1 ]]; then
+        color echoerr "Matches:"
+        indented echoerr "$NAME"
+        usage
+      fi
+      if [[ $COUNT -eq 1 ]]; then
+        APP="$l/$NAME"
+        break
+      fi
+    done
+    if [ -z "$APP" ]; then
+      usage
+    else
+      echo "$APP"
+    fi
+  '';
+
+  idownload = pkgs.writeShellScriptBin "idownload" ''
+    if [ "$#" -ne 1 ] || ! [ -e $1 ]; then
+        echo "Usage: idownload <file|dir>";
+        return 1;
+      fi
+      find . -name '.*icloud' |\
+      perl -pe 's|(.*)/.(.*).icloud|$1/$2|s' |\
+      while read file; do brctl download "$file"; done
+  '';
+
+  nix-link-macapps = pkgs.writeShellScriptBin "nix-link-macapps" ''
+    #see https://raw.githubusercontent.com/matthewbauer/macNixOS/master/link-apps.sh
+    NIX_APPS="$HOME"/.nix-profile/Applications
+    APP_DIR="$HOME"/Applications
+
+    # ensure ~/Applications exists
+    mkdir -p $APP_DIR
+
+    # create links
+    pushd "$APP_DIR" > /dev/null
+    find "$NIX_APPS" -type l -exec ln -fs {} . ';'
+    popd > /dev/null
+
+    # remove broken links
+    find -L "$APP_DIR" -type l -exec rm -- {} +
+  '';
+
+  nix-open = pkgs.writeShellScriptBin "nix-open" ''
+    function usage {
+      echo "Usage: nix-open application [args...]"
+      exit 1
+    }
+    [[ $# -lt 1 ]] && usage
+    NAME=$1; shift
+    APP=$(${app-path}/bin/app-path "$NAME")
+    if [ -z "$APP" ]; then
+      usage
+    else
+      open -a "$APP" "$@"
+    fi
+  '';
+
+  nix-reopen = pkgs.writeShellScriptBin "nix-reopen" ''
+    function usage {
+      echo "Usage: nix-reopen application [args...]"
+      exit 1
+    }
+    [[ $# -lt 1 ]] && usage
+    LOCATIONS=( "~/.nix-profile/Applications" "~/Applications" "/Applications" )
+    NAME=$1
+    APP=$(${app-path}/bin/app-path "$NAME")
+    if [ -z "$APP" ]; then
+      usage
+    else
+      PNAME=$(defaults read "$APP/Contents/Info" CFBundleExecutable)
+      PIDSCOUNT=$(pgrep -i "$PNAME" | wc -l)
+      if [[ $PIDSCOUNT -ne 0 ]]; then
+        pkill -QUIT -i "$PNAME"
+      fi
+      ${nix-open}/bin/nix-open "$@"
+    fi
+  '';
+
+  sudo-with-touch = pkgs.writeShellScriptBin "sudo-with-touch" ''
+    primary=$(cat /etc/pam.d/sudo | head -2 | tail -1 | awk '{$1=$1}1' OFS=",")
+    if [ "auth,sufficient,pam_tid.so" != "$primary" ]; then
+      newsudo=$(mktemp)
+      awk 'NR==2{print "auth       sufficient     pam_tid.so"}7' /etc/pam.d/sudo > $newsudo
+      sudo mv $newsudo /etc/pam.d/sudo
+    fi
+  '';
+
+
+  customPackages = [
+    future-git
+    jqo
+    markdown
+    nix-system
+  ]
+  ++ lib.optionals stdenv.isDarwin ([
+    app-path
+    idownload
+    nix-link-macapps
+    nix-open
+    nix-reopen
+    sudo-with-touch
+  ]);
+
+in
+{
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes.
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release.
+  #stateVersion = "20.09";
+
+  username = env.username;
+  homeDirectory = env.homedir;
+
+  sessionVariables = helpers.meOptConfig "sessionVariables" {};
+
+  packages = with pkgs; [
+    # EXAMPLES
+    htop
+    fortune
+
+    # NIX BASICS
+    niv
+    nixfmt
+    nix-prefetch-github
+    nix-prefetch-scripts
+    undmg
+    styx
+
+    # TOOLS
+    aspell
+    bc
+    clang
+    coreutils
+    fd
+    ffmpeg
+    gdb
+    gnupg
+    jq
+    nox
+    perl
+    ripgrep
+    silver-searcher
+    taskwarrior
+    tree
+    python38Packages.yamllint
+
+    # CLOUD
+    awscli2
+  ]
+  ++ customPackages;
+}

--- a/lib/defaults/programs.nix
+++ b/lib/defaults/programs.nix
@@ -1,69 +1,65 @@
-{ pkgs, env, helpers, ...}:
+{ pkgs, ...}:
 
-let
-  shellAliases = {};
-
-in
 {
-  autojump = {
-    enable = true;
-  };
-
-  # Since we do not install home-manager, you need to let home-manager
-  # manage your shell, otherwise it will not be able to add its hooks
-  # to your profile.
-  bash = {
-    enable = true;
-    shellAliases = shellAliases;
-  };
-
-  direnv = {
-    enable = true;
-  };
-
-  emacs = {
-    enable = true;
-    extraPackages = epkgs: with epkgs; [
-      nix-mode
-      magit
-    ];
-  };
-
-  git = {
-    enable = true;
-    aliases = {
-      unstage = "reset HEAD --";
-      pr = "pull --rebase";
-      co = "checkout";
-      ci = "commit";
-      c = "commit";
-      b = "branch";
-      p = "push";
-      d = "diff";
-      a = "add";
-      s = "status";
-      f = "fetch";
-      br = "branch";
-      lr = "reflog";
-      l = "log --graph --pretty='%Cred%h%Creset - %C(bold blue)<%an>%Creset %s%C(yellow)%d%Creset %Cgreen(%cr)' --abbrev-commit --date=relative";
-      hist = "log --branches --remotes --decorate --graph --pretty=format:'%C(auto) %>|(15) %h %d %<|(30trunc) %s %>|(100)%C(cyan)%ci %C(yellow)%an %C(cyan)(%ar)'";
-      h = "hist";
+  programs = {
+    autojump = {
+      enable = true;
     };
-    ignores = [
-      ".DS_Store"
-      ".com.apple.backupd*"
-      "*~"
-      "*.swp"
-    ];
-    extraConfig = {
-      core.quotepath = true;
-      merge.conflictstyle = "diff3";
-      pull.rebase = true;
-    };
-  };
 
-  zsh = {
-    enable = true;
-    shellAliases = shellAliases;
+    # Since we do not install home-manager, you need to let home-manager
+    # manage your shell, otherwise it will not be able to add its hooks
+    # to your profile.
+    bash = {
+      enable = true;
+    };
+
+    direnv = {
+      enable = true;
+    };
+
+    emacs = {
+      enable = true;
+      extraPackages = epkgs: with epkgs; [
+        nix-mode
+        magit
+      ];
+    };
+
+    git = {
+      enable = true;
+      aliases = {
+        unstage = "reset HEAD --";
+        pr = "pull --rebase";
+        co = "checkout";
+        ci = "commit";
+        c = "commit";
+        b = "branch";
+        p = "push";
+        d = "diff";
+        a = "add";
+        s = "status";
+        f = "fetch";
+        br = "branch";
+        lr = "reflog";
+        l = "log --graph --pretty='%Cred%h%Creset - %C(bold blue)<%an>%Creset %s%C(yellow)%d%Creset %Cgreen(%cr)' --abbrev-commit --date=relative";
+        hist = "log --branches --remotes --decorate --graph --pretty=format:'%C(auto) %>|(15) %h %d %<|(30trunc) %s %>|(100)%C(cyan)%ci %C(yellow)%an %C(cyan)(%ar)'";
+        h = "hist";
+      };
+      ignores = [
+        ".DS_Store"
+        ".com.apple.backupd*"
+        "*~"
+        "*.swp"
+      ];
+      extraConfig = {
+        core.quotepath = true;
+        merge.conflictstyle = "diff3";
+        pull.rebase = true;
+      };
+    };
+
+    zsh = {
+      enable = true;
+    };
   };
 }

--- a/lib/defaults/programs.nix
+++ b/lib/defaults/programs.nix
@@ -1,0 +1,69 @@
+{ pkgs, env, helpers, ...}:
+
+let
+  shellAliases = {};
+
+in
+{
+  autojump = {
+    enable = true;
+  };
+
+  # Since we do not install home-manager, you need to let home-manager
+  # manage your shell, otherwise it will not be able to add its hooks
+  # to your profile.
+  bash = {
+    enable = true;
+    shellAliases = shellAliases;
+  };
+
+  direnv = {
+    enable = true;
+  };
+
+  emacs = {
+    enable = true;
+    extraPackages = epkgs: with epkgs; [
+      nix-mode
+      magit
+    ];
+  };
+
+  git = {
+    enable = true;
+    aliases = {
+      unstage = "reset HEAD --";
+      pr = "pull --rebase";
+      co = "checkout";
+      ci = "commit";
+      c = "commit";
+      b = "branch";
+      p = "push";
+      d = "diff";
+      a = "add";
+      s = "status";
+      f = "fetch";
+      br = "branch";
+      lr = "reflog";
+      l = "log --graph --pretty='%Cred%h%Creset - %C(bold blue)<%an>%Creset %s%C(yellow)%d%Creset %Cgreen(%cr)' --abbrev-commit --date=relative";
+      hist = "log --branches --remotes --decorate --graph --pretty=format:'%C(auto) %>|(15) %h %d %<|(30trunc) %s %>|(100)%C(cyan)%ci %C(yellow)%an %C(cyan)(%ar)'";
+      h = "hist";
+    };
+    ignores = [
+      ".DS_Store"
+      ".com.apple.backupd*"
+      "*~"
+      "*.swp"
+    ];
+    extraConfig = {
+      core.quotepath = true;
+      merge.conflictstyle = "diff3";
+      pull.rebase = true;
+    };
+  };
+
+  zsh = {
+    enable = true;
+    shellAliases = shellAliases;
+  };
+}


### PR DESCRIPTION
Fix the configuration to properly use modules.

By default home.nix loads `lib/defaults/*.nix` (where a programs and home.nix exist).
It now also loads `~/.me.d/*.nix` for personlisations.

At a minimum, users should create ~/.me.d/git.nix defining `programs.git.userName` and `programs.git.userEmail` properties.